### PR TITLE
Fixed bug with 404 "Get Station Info" popup.

### DIFF
--- a/fixedsites/njtransit.com/index.html
+++ b/fixedsites/njtransit.com/index.html
@@ -17,7 +17,7 @@
             if (lstStationList.selectedIndex > 0) {
                   var selectedvalue = lstStationList.options[lstStationList.selectedIndex].value;
                   var atisId = selectedvalue.substring(0,selectedvalue.indexOf("_"));
-                  newwin=window.open('/rg/rg_servlet.srv?hdnPageAction=TrainStationInfoFrom&selStation='+escape(atisId),'name','status=no,location=no,toolbar=no,menubar=no,resizable=yes,scrollbars=yes,height=500,width=800');
+                  newwin=window.open('http://www.njtransit.com/rg/rg_servlet.srv?hdnPageAction=TrainStationInfoFrom&selStation='+escape(atisId),'name','status=no,location=no,toolbar=no,menubar=no,resizable=yes,scrollbars=yes,height=500,width=800');
                   newwin.focus();
             }
             else {
@@ -218,97 +218,97 @@ min-height: 50px;
 <!-- Google Ads Div -->
 <img src="http://www.njtransit.com/images/spacer.gif" alt="" width="1" height="9" border="0"><br>
 <div align="center">
-  <div id="adsenseHeader"></div>	
-    <div id="adsenseHeader-loader" style="display:block;">
-	    <script async="" src="http://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
-		<!-- Train Schedules & Fares -->
-		    <ins class="adsbygoogle" style="display:inline-block;width:728px;height:90px" data-ad-client="ca-pub-7698699613857784" data-ad-slot="9844538165"></ins>
-		  <script>
-		 (adsbygoogle = window.adsbygoogle || []).push({});
-		</script>
-	<!--<script type="text/javascript" src="http://pagead2.googlesyndication.com/pagead/show_ads.js"></script>-->
-	</div>	
- </div>
+<div id="adsenseHeader"></div>	
+<div id="adsenseHeader-loader" style="display:block;">
+    <script async="" src="http://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+	<!-- Train Schedules & Fares -->
+	    <ins class="adsbygoogle" style="display:inline-block;width:728px;height:90px" data-ad-client="ca-pub-7698699613857784" data-ad-slot="9844538165"></ins>
+	  <script>
+	 (adsbygoogle = window.adsbygoogle || []).push({});
+	</script>
+<!--<script type="text/javascript" src="http://pagead2.googlesyndication.com/pagead/show_ads.js"></script>-->
+</div>	
+</div>
 <img src="http://www.njtransit.com/images/spacer.gif" alt="" width="1" height="9" border="0">
 <!-- Google Ads Div -->
 
 <table align="center" border="0" cellspacing="0" cellpadding="0">
 <!-- <tr>
-	<td colspan="3">
-		<div class="content-module">
-		<div style="position:relative; top:10px; left:10px; width:940px;">
-		<table border="0" cellspacing="0" cellpadding="0">
-			<tr><td>
-		NJ TRANSIT operates the state's commuter rail network. The rail system features 11 lines in three divisions. Customers can transfer between all lines, except Atlantic City Rail Line, at the new Secaucus Junction station. (The Raritan Valley Line requires an additional transfer at Newark Penn Station.)<br>
-			</td></tr>
-			<tr><td><img src="http://www.njtransit.com/images/spacer.gif" border="0" height="12" width="1" alt=""></td></tr>
+<td colspan="3">
+	<div class="content-module">
+	<div style="position:relative; top:10px; left:10px; width:940px;">
+	<table border="0" cellspacing="0" cellpadding="0">
 		<tr><td>
-		<ul style="*margin-bottom:10px;">
-			<li><img src="http://www.njtransit.com/images/spacer.gif" border="0" height="1" width="1" alt=""><span class="emphasis">The Hoboken Division</span> (includes the MidTOWN DIRECT service on the Morris & Essex and Montclair-Boonton lines to and from Penn Station New York and lines operating to and from Hoboken Terminal on the Morris & Essex, Main/Bergen, Pascack Valley and Montclair-Boonton lines).</li>
-			<li><img src="http://www.njtransit.com/images/spacer.gif" border="0" height="20" width="1" alt=""><span class="emphasis">The Newark Division</span> (includes the Northeast Corridor, North Jersey Coast, and Raritan Valley lines operating to and from Newark Penn Station, Hoboken Terminal, and Penn Station New York).</li>
-			<li><img src="http://www.njtransit.com/images/spacer.gif" border="0" height="20" width="1" alt=""><span class="emphasis">The Atlantic City Rail Line</span> (operates between the seaside resort city and Philadelphia, serving points in between).</li>
-		</ul>
-			</td></tr>
-			<tr><td>
-		NJ TRANSIT also runs rail service to and from points in New York State on the Pascack Valley and Port Jervis lines under contract with the Metropolitan Transportation Authority. NJ TRANSIT's rail network provides links to the region's other transit systems. Transfers to the state's bus system are possible at many rail stations, while at Penn Station New York, connections are available to Amtrak, the Long Island Railroad, and the New York City subway system. At Trenton, riders can connect to SEPTA and Amtrak.
-			</td></tr>
-			<tr><td><img src="http://www.njtransit.com/images/spacer.gif" border="0" height="12" width="1" alt=""></td></tr>
-			<tr><td>
-		At NJ TRANSIT's Hoboken Terminal, transfers can be made to PATH trains between Hoboken, Jersey City, Newark, and midtown Manhattan; to Manhattan-bound ferry service; and to NJ TRANSIT's Hudson-Bergen Light Rail System. At Newark Broad Street Station, connections are available to NJ TRANSIT's Newark Light Rail. At Newark Penn Station, the state's busiest transit hub, connections to Amtrak, PATH and NJ TRANSIT's Newark Light Rail are available. PATH can be used to connect with NJ TRANSIT's Hudson-Bergen Light Rail System. On South Jersey's Atlantic City Rail Line, connections can be made to Amtrak and SEPTA at Philadelphia's 30th Street Station.
-			</td></tr>
-			<tr><td><img src="http://www.njtransit.com/images/spacer.gif" border="0" height="12" width="1" alt=""></td></tr>
-			<tr><td>
-		Click here to view a PDF <a href="http://www.njtransit.com/pdf/rail/Rail_System_Map.pdf" target="_blank">map of the NJ TRANSIT rail system. </a>
-			</td></tr>
-			<tr><td><img src="http://www.njtransit.com/images/spacer.gif" border="0" height="12" width="1" alt=""></td></tr>
-			<tr><td>
-		Visit our <a href="sf_servlet.srv?hdnPageAction=TrainFareOptionsTo">Fare Options</a> section to learn more about the different fare options available for train rides.
-			</td></tr>
-			<tr><td><img src="http://www.njtransit.com/images/spacer.gif" border="0" height="12" width="1" alt=""></td></tr>
-			<tr><td>
-		For trips that include transfer to bus, light rail or more than two rail transfers, use <a href="sf_servlet.srv?hdnPageAction=TripPlannerItineraryTo">Itinerary Planner.</a>
-			</td></tr>
-		</table>
-		</div>
-		</div>
-	</td>
-	</tr>-->
+	NJ TRANSIT operates the state's commuter rail network. The rail system features 11 lines in three divisions. Customers can transfer between all lines, except Atlantic City Rail Line, at the new Secaucus Junction station. (The Raritan Valley Line requires an additional transfer at Newark Penn Station.)<br>
+		</td></tr>
+		<tr><td><img src="http://www.njtransit.com/images/spacer.gif" border="0" height="12" width="1" alt=""></td></tr>
+	<tr><td>
+	<ul style="*margin-bottom:10px;">
+		<li><img src="http://www.njtransit.com/images/spacer.gif" border="0" height="1" width="1" alt=""><span class="emphasis">The Hoboken Division</span> (includes the MidTOWN DIRECT service on the Morris & Essex and Montclair-Boonton lines to and from Penn Station New York and lines operating to and from Hoboken Terminal on the Morris & Essex, Main/Bergen, Pascack Valley and Montclair-Boonton lines).</li>
+		<li><img src="http://www.njtransit.com/images/spacer.gif" border="0" height="20" width="1" alt=""><span class="emphasis">The Newark Division</span> (includes the Northeast Corridor, North Jersey Coast, and Raritan Valley lines operating to and from Newark Penn Station, Hoboken Terminal, and Penn Station New York).</li>
+		<li><img src="http://www.njtransit.com/images/spacer.gif" border="0" height="20" width="1" alt=""><span class="emphasis">The Atlantic City Rail Line</span> (operates between the seaside resort city and Philadelphia, serving points in between).</li>
+	</ul>
+		</td></tr>
+		<tr><td>
+	NJ TRANSIT also runs rail service to and from points in New York State on the Pascack Valley and Port Jervis lines under contract with the Metropolitan Transportation Authority. NJ TRANSIT's rail network provides links to the region's other transit systems. Transfers to the state's bus system are possible at many rail stations, while at Penn Station New York, connections are available to Amtrak, the Long Island Railroad, and the New York City subway system. At Trenton, riders can connect to SEPTA and Amtrak.
+		</td></tr>
+		<tr><td><img src="http://www.njtransit.com/images/spacer.gif" border="0" height="12" width="1" alt=""></td></tr>
+		<tr><td>
+	At NJ TRANSIT's Hoboken Terminal, transfers can be made to PATH trains between Hoboken, Jersey City, Newark, and midtown Manhattan; to Manhattan-bound ferry service; and to NJ TRANSIT's Hudson-Bergen Light Rail System. At Newark Broad Street Station, connections are available to NJ TRANSIT's Newark Light Rail. At Newark Penn Station, the state's busiest transit hub, connections to Amtrak, PATH and NJ TRANSIT's Newark Light Rail are available. PATH can be used to connect with NJ TRANSIT's Hudson-Bergen Light Rail System. On South Jersey's Atlantic City Rail Line, connections can be made to Amtrak and SEPTA at Philadelphia's 30th Street Station.
+		</td></tr>
+		<tr><td><img src="http://www.njtransit.com/images/spacer.gif" border="0" height="12" width="1" alt=""></td></tr>
+		<tr><td>
+	Click here to view a PDF <a href="http://www.njtransit.com/pdf/rail/Rail_System_Map.pdf" target="_blank">map of the NJ TRANSIT rail system. </a>
+		</td></tr>
+		<tr><td><img src="http://www.njtransit.com/images/spacer.gif" border="0" height="12" width="1" alt=""></td></tr>
+		<tr><td>
+	Visit our <a href="sf_servlet.srv?hdnPageAction=TrainFareOptionsTo">Fare Options</a> section to learn more about the different fare options available for train rides.
+		</td></tr>
+		<tr><td><img src="http://www.njtransit.com/images/spacer.gif" border="0" height="12" width="1" alt=""></td></tr>
+		<tr><td>
+	For trips that include transfer to bus, light rail or more than two rail transfers, use <a href="sf_servlet.srv?hdnPageAction=TripPlannerItineraryTo">Itinerary Planner.</a>
+		</td></tr>
+	</table>
+	</div>
+	</div>
+</td>
+</tr>-->
 
-	  <tbody><tr>
-	  	<td colspan="3"><img src="http://www.njtransit.com/images/rail_schedules_header.jpg" alt="" width="960" height="226" border="0"></td>
-	  </tr>
-	
+  <tbody><tr>
+	<td colspan="3"><img src="http://www.njtransit.com/images/rail_schedules_header.jpg" alt="" width="960" height="226" border="0"></td>
+  </tr>
+
 
 <!-- RED NOTE BY LINE GOES BELOW -->
 
-	 
-		<!-- 	<tr>
-			      <td align="left" colspan="3"><br/><span style="color:red;"><strong>IMPORTANT NOTE:</strong>Atlantic City Line trains are replaced by buses between Philadelphia and Cherry Hill from 1:30 AM Saturday, March 15 until 4:30 AM Tuesday, March 18. During this time, Pennsauken station will be served by a combination of buses and alternate service. In certain cases, buses departing Philadelphia and Pennsauken for Cherry Hill will depart earlier than the scheduled train times. See <a target="_blank" href="http://www.njtransit.com/sa/sa_servlet.srv?hdnPageAction=ServiceAdjustmentTo&AdjustmentId=10756">customer notice</a> for further details.</span><br/></td>
-			                                                                                            
-			</tr>-->
-	
- <!--  RED NOTE ENDS HERE -->
-	 
-      <tr>
-            <td valign="top">
-               <div class="AccordionSchedules" tabindex="0">
-	 		<div class="AccordionPanel">
-	            	<div class="AccordionPanelTab">Train Schedules</div>
-	            	<div class="AccordionPanelContent" style="height:180px;*height:210px;">	
-					<form name="frm_tr_schedules" action="http://www.njtransit.com/sf/sf_servlet.srv" method="GET">
-                              <input type="hidden" name="hdnPageAction" value="TrainSchedulesFrom" />
-			                  <table border="0" cellspacing="0" cellpadding="4">
-			                  <tbody><tr>
-			                        <td align="center" colspan="2">
-			                        	<img src="http://www.njtransit.com/images/spacer.gif" alt="" width="25" height="1" border="0"><a href="http://www.njtransit.com/sf/sf_servlet.srv?hdnPageAction=TrainTo#" onclick="showMapWindow()">Use Our Rail Map to Select Stations</a>
-			                            <!-- <input type=button value="Use Our Rail Map to Plan Your Trip" onClick="showMapWindow()">-->
-			                        </td>
-			                  </tr>
-			                  <tr>
-			                        <td valign="top" align="right"><span class="emphasis">Origin Station : </span></td>
-			                        <td align="left">
-			                        	<span class="notranslate">
-			                              <select name="selOrigin">
+ 
+	<!-- 	<tr>
+		      <td align="left" colspan="3"><br/><span style="color:red;"><strong>IMPORTANT NOTE:</strong>Atlantic City Line trains are replaced by buses between Philadelphia and Cherry Hill from 1:30 AM Saturday, March 15 until 4:30 AM Tuesday, March 18. During this time, Pennsauken station will be served by a combination of buses and alternate service. In certain cases, buses departing Philadelphia and Pennsauken for Cherry Hill will depart earlier than the scheduled train times. See <a target="_blank" href="http://www.njtransit.com/sa/sa_servlet.srv?hdnPageAction=ServiceAdjustmentTo&AdjustmentId=10756">customer notice</a> for further details.</span><br/></td>
+													    
+		</tr>-->
+
+<!--  RED NOTE ENDS HERE -->
+ 
+<tr>
+    <td valign="top">
+       <div class="AccordionSchedules" tabindex="0">
+		<div class="AccordionPanel">
+		<div class="AccordionPanelTab">Train Schedules</div>
+		<div class="AccordionPanelContent" style="height:180px;*height:210px;">	
+				<form name="frm_tr_schedules" action="http://www.njtransit.com/sf/sf_servlet.srv" method="GET">
+		      <input type="hidden" name="hdnPageAction" value="TrainSchedulesFrom" />
+				  <table border="0" cellspacing="0" cellpadding="4">
+				  <tbody><tr>
+					<td align="center" colspan="2">
+						<img src="http://www.njtransit.com/images/spacer.gif" alt="" width="25" height="1" border="0"><a href="http://www.njtransit.com/sf/sf_servlet.srv?hdnPageAction=TrainTo#" onclick="showMapWindow()">Use Our Rail Map to Select Stations</a>
+					    <!-- <input type=button value="Use Our Rail Map to Plan Your Trip" onClick="showMapWindow()">-->
+					</td>
+				  </tr>
+				  <tr>
+					<td valign="top" align="right"><label for="selOrigin" accesskey="o"><span class="emphasis">Origin Station : </span></label></td>
+					<td align="left">
+						<span class="notranslate">
+					      <select name="selOrigin" id="selOrigin">
 			                                    <option value="">Select Station</option>
 			                              
 			                                                	<option value="37169_NJCL">Aberdeen Matawan</option>
@@ -649,10 +649,10 @@ min-height: 50px;
 			                        </td>
 			                  </tr>
 			                  <tr>
-			                        <td valign="top" align="right"><span class="emphasis">Destination Station : </span></td>
+			                        <td valign="top" align="right"><label for="selDestination" accesskey="d"><span class="emphasis">Destination Station : </span></label></td>
 			                        <td align="left">
 			                        	<span class="notranslate">
-			                              <select name="selDestination">
+			                              <select name="selDestination" id="selDestination">
 			                                    <option value="">Select Station</option>
 			                                    
 				                                                	<option value="37169_NJCL">Aberdeen Matawan</option>
@@ -991,9 +991,9 @@ min-height: 50px;
 			                        </td>
 			                  </tr>
 			                  <tr>
-			                        <td valign="top" align="right"><span class="emphasis">Date of Travel : </span></td>
+			                        <td valign="top" align="right"><label for="datepicker" accesskey="p"><span class="emphasis">Date of Travel : </span></label></td>
 			                        <td colspan="1" valign="top" align="left">
-								<input name="datepicker" type="text" autocomplete="on" class="datepicker dp-applied" id="datepicker" title="">
+								<input name="datepicker" id="datepicker" type="text" autocomplete="on" class="datepicker dp-applied" id="datepicker" title="">
 								<!-- <br>-->
 			                              <!-- <a style="font-size:7pt;" href="#" onClick="showHolidayWindow()">Holiday Travel Note</a>-->
 			                              <!-- <input type=button value="Holiday Travel Note" onClick="showHolidayWindow()">-->

--- a/fixedsites/njtransit.com/whatifixed.md
+++ b/fixedsites/njtransit.com/whatifixed.md
@@ -3,3 +3,5 @@
 3. your search result can now be bookmarked  
     (TIP: you can leave the date field empty if you want your bookmark to automatically use the current day)
 4. added "reverse trip" button
+5. Added labels for accessibility.  You can now click on names to access form elements.
+6. Added accesskey for quick access (on firefox ctrl-option-o origin station, ctrl-option-d destination station, ctrl-option-t travel date)


### PR DESCRIPTION
Fixed bug with 404 "Get Station Info" popup.
Added labels for accessibility.  You can now click on names to access form elements.
Added accesskey for quick access (on firefox ctrl-option-o origin station, ctrl-option-d destination station, ctrl-option-t travel date)
